### PR TITLE
Add missing REST API endpoints and WS streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ dist/
 
 # MacOS
 .DS_Store
+
+*.env

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ lint:
 		-i 70612 \
 		-i 70630 \
 		-i 71064 \
-		-i 71545
+		-i 71545 \
+		-i 71591 \
+		-i 71608
 	black --check --diff --target-version py310 --line-length 120 ./examples ./tests ./x10
 	flake8 ./examples ./tests ./x10
 	mypy

--- a/tests/perpetual/test_order_object.py
+++ b/tests/perpetual/test_order_object.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 from freezegun import freeze_time
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, has_entries
 from pytest_mock import MockerFixture
 
 from x10.perpetual.orders import OrderSide
@@ -43,18 +43,10 @@ async def test_create_sell_order(mocker: MockerFixture, create_trading_account, 
                 "reduceOnly": False,
                 "postOnly": False,
                 "timeInForce": "GTT",
-                "fee": "0.0005",
                 "expiryEpochMillis": 1705021736860,
+                "fee": "0.0005",
                 "nonce": "1473459052",
-                "payedFee": None,
-                "takeProfitSignature": None,
-                "stopLossSignature": None,
                 "cancelId": None,
-                "triggerPrice": None,
-                "takeProfitPrice": None,
-                "takeProfitLimitPrice": None,
-                "stopLossPrice": None,
-                "stopLossLimitPrice": None,
                 "settlement": {
                     "signature": {
                         "r": "0x6036ac4ade5f5dfb1d293450fbf3a6864be35d3d90f78c61a6e97ed08af60ad",
@@ -63,11 +55,11 @@ async def test_create_sell_order(mocker: MockerFixture, create_trading_account, 
                     "starkKey": "0x61c5e7e8339b7d56f197f54ea91b776776690e3232313de0f2ecbd0ef76f466",
                     "collateralPosition": "10002",
                 },
-                "debuggingAmounts": {
-                    "collateralAmount": "43445116",
-                    "feeAmount": "21723",
-                    "syntheticAmount": "1000",
-                },
+                "trigger": None,
+                "tpSlType": None,
+                "takeProfit": None,
+                "stopLoss": None,
+                "debuggingAmounts": {"collateralAmount": "43445116", "feeAmount": "21723", "syntheticAmount": "1000"},
             }
         ),
     )
@@ -104,18 +96,10 @@ async def test_create_buy_order(mocker: MockerFixture, create_trading_account, c
                 "reduceOnly": False,
                 "postOnly": False,
                 "timeInForce": "GTT",
-                "fee": "0.0005",
                 "expiryEpochMillis": 1705021736860,
+                "fee": "0.0005",
                 "nonce": "1473459052",
-                "payedFee": None,
-                "takeProfitSignature": None,
-                "stopLossSignature": None,
                 "cancelId": None,
-                "triggerPrice": None,
-                "takeProfitPrice": None,
-                "takeProfitLimitPrice": None,
-                "stopLossPrice": None,
-                "stopLossLimitPrice": None,
                 "settlement": {
                     "signature": {
                         "r": "0xc68d574e2e92138f799068506a5e2840083ff1a6e3d65498f38e3bf7dd1c95",
@@ -124,11 +108,69 @@ async def test_create_buy_order(mocker: MockerFixture, create_trading_account, c
                     "starkKey": "0x61c5e7e8339b7d56f197f54ea91b776776690e3232313de0f2ecbd0ef76f466",
                     "collateralPosition": "10002",
                 },
-                "debuggingAmounts": {
-                    "collateralAmount": "43445117",
-                    "feeAmount": "21723",
-                    "syntheticAmount": "1000",
-                },
+                "trigger": None,
+                "tpSlType": None,
+                "takeProfit": None,
+                "stopLoss": None,
+                "debuggingAmounts": {"collateralAmount": "43445117", "feeAmount": "21723", "syntheticAmount": "1000"},
+            }
+        ),
+    )
+
+
+@freeze_time("2024-01-05 01:08:56.860694")
+@pytest.mark.asyncio
+async def test_cancel_previous_order(mocker: MockerFixture, create_trading_account, create_btc_usd_market):
+    mocker.patch("x10.utils.starkex.generate_nonce", return_value=FROZEN_NONCE)
+
+    from x10.perpetual.order_object import create_order_object
+
+    trading_account = create_trading_account()
+    btc_usd_market = create_btc_usd_market()
+    order_obj = create_order_object(
+        account=trading_account,
+        market=btc_usd_market,
+        amount_of_synthetic=Decimal("0.00100000"),
+        price=Decimal("43445.11680000"),
+        side=OrderSide.BUY,
+        expire_time=utc_now() + timedelta(days=7),
+        previous_order_id="previous_custom_id",
+    )
+
+    assert_that(
+        order_obj.to_api_request_json(),
+        has_entries(
+            {
+                "cancelId": equal_to("previous_custom_id"),
+            }
+        ),
+    )
+
+
+@freeze_time("2024-01-05 01:08:56.860694")
+@pytest.mark.asyncio
+async def test_external_order_id(mocker: MockerFixture, create_trading_account, create_btc_usd_market):
+    mocker.patch("x10.utils.starkex.generate_nonce", return_value=FROZEN_NONCE)
+
+    from x10.perpetual.order_object import create_order_object
+
+    trading_account = create_trading_account()
+    btc_usd_market = create_btc_usd_market()
+    order_obj = create_order_object(
+        account=trading_account,
+        market=btc_usd_market,
+        amount_of_synthetic=Decimal("0.00100000"),
+        price=Decimal("43445.11680000"),
+        side=OrderSide.BUY,
+        expire_time=utc_now() + timedelta(days=7),
+        order_external_id="custom_id",
+    )
+
+    assert_that(
+        order_obj.to_api_request_json(),
+        has_entries(
+            {
+                "id": equal_to("custom_id"),
             }
         ),
     )

--- a/x10/perpetual/fees.py
+++ b/x10/perpetual/fees.py
@@ -5,12 +5,12 @@ from x10.utils.model import X10BaseModel
 
 class TradingFeeModel(X10BaseModel):
     market: str
-    maker_fee: Decimal
-    taker_fee: Decimal
+    maker_fee_rate: Decimal
+    taker_fee_rate: Decimal
 
 
 DEFAULT_FEES = TradingFeeModel(
     market="BTC-USD",
-    maker_fee=(Decimal("2") / Decimal("10000")),
-    taker_fee=(Decimal("5") / Decimal("10000")),
+    maker_fee_rate=(Decimal("2") / Decimal("10000")),
+    taker_fee_rate=(Decimal("5") / Decimal("10000")),
 )

--- a/x10/perpetual/order_object.py
+++ b/x10/perpetual/order_object.py
@@ -34,6 +34,7 @@ def create_order_object(
     post_only: bool = False,
     previous_order_id=None,
     expire_time=utc_now() + timedelta(hours=8),
+    external_id=None,
 ) -> PerpetualOrderModel:
     """
     Creates an order object to be placed on the exchange using the `place_order` method.
@@ -52,6 +53,7 @@ def create_order_object(
         expire_time,
         post_only=post_only,
         previous_order_id=previous_order_id,
+        external_id=external_id,
     )
 
 
@@ -68,6 +70,7 @@ def __create_order_object(
     expire_time: datetime = utc_now() + timedelta(hours=1),
     post_only: bool = False,
     previous_order_id=None,
+    external_id=None,
 ) -> PerpetualOrderModel:
     if exact_only:
         raise NotImplementedError("`exact_only` option is not supported yet")
@@ -103,7 +106,7 @@ def __create_order_object(
     (order_signature_r, order_signature_s) = signer(order_hash)
 
     order = PerpetualOrderModel(
-        id=str(order_hash),
+        id=str(order_hash) if external_id is None else external_id,
         market=market.name,
         type=OrderType.LIMIT,
         side=side,

--- a/x10/perpetual/order_object.py
+++ b/x10/perpetual/order_object.py
@@ -115,8 +115,9 @@ def __create_order_object(
         collateral_position=Decimal(collateral_position_id),
     )
 
+    order_id = str(order_hash) if order_external_id is None else order_external_id
     order = PerpetualOrderModel(
-        id=order_external_id or str(order_hash),
+        id=order_id,
         market=market.name,
         type=OrderType.LIMIT,
         side=side,

--- a/x10/perpetual/order_object.py
+++ b/x10/perpetual/order_object.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from x10.perpetual.accounts import StarkPerpetualAccount
 from x10.perpetual.amounts import (
@@ -32,8 +32,9 @@ def create_order_object(
     price: Decimal,
     side: OrderSide,
     post_only: bool = False,
-    previous_order_id=None,
+    previous_order_id: Optional[str] = None,
     expire_time=utc_now() + timedelta(hours=8),
+    order_external_id: Optional[str] = None,
 ) -> PerpetualOrderModel:
     """
     Creates an order object to be placed on the exchange using the `place_order` method.
@@ -51,7 +52,8 @@ def create_order_object(
         False,
         expire_time,
         post_only=post_only,
-        previous_order_id=previous_order_id,
+        previous_order_external_id=previous_order_id,
+        order_external_id=order_external_id,
     )
 
 
@@ -67,7 +69,8 @@ def __create_order_object(
     exact_only: bool = False,
     expire_time: datetime = utc_now() + timedelta(hours=1),
     post_only: bool = False,
-    previous_order_id=None,
+    previous_order_external_id: Optional[str] = None,
+    order_external_id: Optional[str] = None,
 ) -> PerpetualOrderModel:
     if exact_only:
         raise NotImplementedError("`exact_only` option is not supported yet")
@@ -80,7 +83,7 @@ def __create_order_object(
     synthetic_amount_human = HumanReadableAmount(synthetic_amount, market.synthetic_asset)
 
     fee = HumanReadableAmount(
-        fees.taker_fee * collateral_amount_human.value,
+        fees.taker_fee_rate * collateral_amount_human.value,
         market.collateral_asset,
     )
 
@@ -88,8 +91,13 @@ def __create_order_object(
         collateral_amount_internal=collateral_amount_human,
         synthetic_amount_internal=synthetic_amount_human,
         fee_amount_internal=fee,
-        fee_rate=fees.taker_fee,
+        fee_rate=fees.taker_fee_rate,
         rounding_context=rounding_context,
+    )
+    debugging_amounts = StarkDebuggingOrderAmountsModel(
+        collateral_amount=Decimal(amounts.collateral_amount_internal.to_stark_amount(amounts.rounding_context).value),
+        fee_amount=Decimal(amounts.fee_amount_internal.to_stark_amount(ROUNDING_FEE_CONTEXT).value),
+        synthetic_amount=Decimal(amounts.synthetic_amount_internal.to_stark_amount(amounts.rounding_context).value),
     )
 
     order_hash = hash_order(
@@ -101,40 +109,27 @@ def __create_order_object(
     )
 
     (order_signature_r, order_signature_s) = signer(order_hash)
+    settlement = StarkSettlementModel(
+        signature=SignatureModel(r=order_signature_r, s=order_signature_s),
+        stark_key=public_key,
+        collateral_position=Decimal(collateral_position_id),
+    )
 
     order = PerpetualOrderModel(
-        id=str(order_hash),
+        id=order_external_id or str(order_hash),
         market=market.name,
         type=OrderType.LIMIT,
         side=side,
         qty=synthetic_amount_human.value,
         price=price,
-        reduce_only=False,
         post_only=post_only,
         time_in_force=TimeInForce.GTT,
-        fee=amounts.fee_rate,
         expiry_epoch_millis=to_epoch_millis(expire_time),
-        settlement=StarkSettlementModel(
-            signature=SignatureModel(r=order_signature_r, s=order_signature_s),
-            stark_key=public_key,
-            collateral_position=Decimal(collateral_position_id),
-        ),
+        fee=amounts.fee_rate,
         nonce=Decimal(nonce),
-        take_profit_signature=None,
-        stop_loss_signature=None,
-        cancel_id=previous_order_id,
-        trigger_price=None,
-        take_profit_price=None,
-        take_profit_limit_price=None,
-        stop_loss_price=None,
-        stop_loss_limit_price=None,
-        debugging_amounts=StarkDebuggingOrderAmountsModel(
-            collateral_amount=Decimal(
-                amounts.collateral_amount_internal.to_stark_amount(amounts.rounding_context).value
-            ),
-            fee_amount=Decimal(amounts.fee_amount_internal.to_stark_amount(ROUNDING_FEE_CONTEXT).value),
-            synthetic_amount=Decimal(amounts.synthetic_amount_internal.to_stark_amount(amounts.rounding_context).value),
-        ),
+        cancel_id=previous_order_external_id,
+        settlement=settlement,
+        debugging_amounts=debugging_amounts,
     )
 
     return order

--- a/x10/perpetual/orders.py
+++ b/x10/perpetual/orders.py
@@ -23,20 +23,30 @@ class OrderType(Enum):
     MARKET = "MARKET"
 
 
+class OrderTpslType(Enum):
+    ORDER = "ORDER"
+    POSITION = "POSITION"
+
+
 class OrderStatus(Enum):
+    # Technical status
     UNKNOWN = "UNKNOWN"
+
     NEW = "NEW"
-    UNTRIGGERED = "UNTRIGGERED"
     PARTIALLY_FILLED = "PARTIALLY_FILLED"
     FILLED = "FILLED"
+    UNTRIGGERED = "UNTRIGGERED"
     CANCELLED = "CANCELLED"
-    EXPIRED = "EXPIRED"
     REJECTED = "REJECTED"
+    EXPIRED = "EXPIRED"
+    TRIGGERED = "TRIGGERED"
 
 
 class OrderStatusReason(Enum):
-    NONE = "NONE"
+    # Technical status
     UNKNOWN = "UNKNOWN"
+
+    NONE = "NONE"
     UNKNOWN_MARKET = "UNKNOWN_MARKET"
     DISABLED_MARKET = "DISABLED_MARKET"
     NOT_ENOUGH_FUNDS = "NOT_ENOUGH_FUNDS"
@@ -56,6 +66,31 @@ class OrderStatusReason(Enum):
     PREV_ORDER_TRIGGERED = "PREV_ORDER_TRIGGERED"
 
 
+class OrderTriggerPriceType(Enum):
+    # Technical status
+    UNKNOWN = "UNKNOWN"
+
+    MARK = "MARK"
+    INDEX = "INDEX"
+    LAST = "LAST"
+
+
+class OrderTriggerDirection(Enum):
+    # Technical status
+    UNKNOWN = "UNKNOWN"
+
+    UP = "UP"
+    DOWN = "DOWN"
+
+
+class OrderPriceType(Enum):
+    # Technical status
+    UNKNOWN = "UNKNOWN"
+
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+
+
 class SignatureModel(X10BaseModel):
     r: HexValue
     s: HexValue
@@ -73,6 +108,22 @@ class StarkDebuggingOrderAmountsModel(X10BaseModel):
     synthetic_amount: Decimal
 
 
+class CreateOrderConditionalTriggerModel(X10BaseModel):
+    trigger_price: Decimal
+    trigger_price_type: OrderTriggerPriceType
+    direction: OrderTriggerDirection
+    execution_price_type: OrderPriceType
+
+
+class CreateOrderTpslTriggerModel(X10BaseModel):
+    trigger_price: Decimal
+    trigger_price_type: OrderTriggerPriceType
+    price: Decimal
+    price_type: OrderPriceType
+    settlement: StarkSettlementModel
+    debugging_amounts: Optional[StarkDebuggingOrderAmountsModel] = None
+
+
 class PerpetualOrderModel(X10BaseModel):
     id: str
     market: str
@@ -80,22 +131,18 @@ class PerpetualOrderModel(X10BaseModel):
     side: OrderSide
     qty: Decimal
     price: Decimal
-    reduce_only: bool
-    post_only: bool
+    reduce_only: bool = False
+    post_only: bool = False
     time_in_force: TimeInForce
-    fee: Decimal
     expiry_epoch_millis: int
+    fee: Decimal
     nonce: Decimal
-    payed_fee: Optional[Decimal] = None
-    take_profit_signature: Optional[str] = None
-    stop_loss_signature: Optional[str] = None
-    cancel_id: Optional[int] = None
-    trigger_price: Optional[Decimal] = None
-    take_profit_price: Optional[Decimal] = None
-    take_profit_limit_price: Optional[Decimal] = None
-    stop_loss_price: Optional[Decimal] = None
-    stop_loss_limit_price: Optional[Decimal] = None
+    cancel_id: Optional[str] = None
     settlement: Optional[StarkSettlementModel] = None
+    trigger: Optional[CreateOrderConditionalTriggerModel] = None
+    tp_sl_type: Optional[OrderTpslType] = None
+    take_profit: Optional[CreateOrderTpslTriggerModel] = None
+    stop_loss: Optional[CreateOrderTpslTriggerModel] = None
     debugging_amounts: Optional[StarkDebuggingOrderAmountsModel] = None
 
 
@@ -119,5 +166,6 @@ class OpenOrderModel(X10BaseModel):
     filled_qty: Optional[Decimal] = None
     reduce_only: bool
     post_only: bool
+    payed_fee: Optional[Decimal] = None
     created_time: int
     expiry_time: Optional[int] = None

--- a/x10/perpetual/trading_client/markets_information_module.py
+++ b/x10/perpetual/trading_client/markets_information_module.py
@@ -58,10 +58,10 @@ class MarketsInformationModule(BaseModule):
 
         url = self._get_url(
             "/info/<market>/funding",
+            market=market_name,
             query={
                 "startTime": to_epoch_millis(start_time),
                 "endTime": to_epoch_millis(end_time),
             },
-            market=market_name,
         )
         return await send_get_request(await self.get_session(), url, List[FundingRateModel])

--- a/x10/perpetual/trading_client/order_management_module.py
+++ b/x10/perpetual/trading_client/order_management_module.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from x10.perpetual.orders import PerpetualOrderModel, PlacedOrderModel
 from x10.perpetual.trading_client.base_module import BaseModule
@@ -10,9 +10,9 @@ LOGGER = get_logger(__name__)
 
 
 class _MassCancelRequestModel(X10BaseModel):
-    order_ids: Optional[list[int]]
-    external_order_ids: Optional[list[str]]
-    markets: Optional[list[str]]
+    order_ids: Optional[List[int]]
+    external_order_ids: Optional[List[str]]
+    markets: Optional[List[str]]
     cancel_all: Optional[bool]
 
 
@@ -43,16 +43,22 @@ class OrderManagementModule(BaseModule):
         """
 
         url = self._get_url("/user/order/<order_id>", order_id=order_id)
-        return await send_delete_request(
-            await self.get_session(), url, EmptyModel, api_key=self._get_api_key(), idempotent=True, retry=True
-        )
+        return await send_delete_request(await self.get_session(), url, EmptyModel, api_key=self._get_api_key())
+
+    async def cancel_order_by_external_id(self, order_external_id: str):
+        """
+        https://x10xchange.github.io/x10-documentation/#cancel-order
+        """
+
+        url = self._get_url("/user/order", query={"externalId": order_external_id})
+        return await send_delete_request(await self.get_session(), url, EmptyModel, api_key=self._get_api_key())
 
     async def mass_cancel(
         self,
         *,
-        order_ids: Optional[list[int]] = None,
-        external_order_ids: Optional[list[str]] = None,
-        markets: Optional[list[str]] = None,
+        order_ids: Optional[List[int]] = None,
+        external_order_ids: Optional[List[str]] = None,
+        markets: Optional[List[str]] = None,
         cancel_all: Optional[bool] = False,
     ):
         """

--- a/x10/utils/http.py
+++ b/x10/utils/http.py
@@ -47,6 +47,9 @@ class WrappedApiResponse(X10BaseModel, Generic[ApiResponseType]):
 
 
 class StreamDataType(Enum):
+    # Technical status
+    UNKNOWN = "UNKNOWN"
+
     BALANCE = "BALANCE"
     DELTA = "DELTA"
     DEPOSIT = "DEPOSIT"
@@ -56,7 +59,6 @@ class StreamDataType(Enum):
     TRADE = "TRADE"
     TRANSFER = "TRANSFER"
     WITHDRAWAL = "WITHDRAWAL"
-    UNKNOWN = "UNKNOWN"
 
     @classmethod
     def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: GetCoreSchemaHandler) -> CoreSchema:
@@ -165,8 +167,6 @@ async def send_delete_request(
     model_class: Type[ApiResponseType],
     *,
     api_key: Optional[str] = None,
-    idempotent: bool = False,
-    retry=False,
 ):
     headers = __get_headers(api_key=api_key)
     LOGGER.debug("Sending DELETE %s, headers=%s", url, headers)


### PR DESCRIPTION
## Changes
- Align SDK with REST API BE / [documentation](https://x10xchange.github.io/x10-documentation)
  - Add `external_id` support
  - Add `cancel_order_by_external_id` method
  - Update `TradingFeeModel` model
  - Update `PerpetualOrderModel` model
  - Fix `payed_fee` field (was added to the wrong model previously)
