### PR TITLE
Fix release GH action Python version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install Poetry
         run: |


### PR DESCRIPTION
## Changes
- Fix Python version (was parsed as `Python 3.1` instead of `Python 3.10`)
