### PR TITLE
Expose account.transfer method

### DIFF
--- a/x10/perpetual/trading_client/account_module.py
+++ b/x10/perpetual/trading_client/account_module.py
@@ -15,7 +15,12 @@ from x10.perpetual.positions import PositionHistoryModel, PositionModel, Positio
 from x10.perpetual.trades import AccountTradeModel, TradeType
 from x10.perpetual.trading_client.base_module import BaseModule
 from x10.perpetual.transfer_object import create_transfer_object
-from x10.utils.http import WrappedApiResponse, send_get_request, send_patch_request
+from x10.utils.http import (
+    WrappedApiResponse,
+    send_get_request,
+    send_patch_request,
+    send_post_request,
+)
 from x10.utils.model import EmptyModel
 
 
@@ -141,7 +146,7 @@ class AccountModule(BaseModule):
             api_key=self._get_api_key(),
         )
 
-    async def __transfer(
+    async def transfer(
         self,
         from_account: int,
         to_account: int,
@@ -161,8 +166,12 @@ class AccountModule(BaseModule):
             market=market,
         )
 
-        return await send_patch_request(
-            await self.get_session(), url, EmptyModel, json=request_model, api_key=self._get_api_key()
+        return await send_post_request(
+            await self.get_session(),
+            url,
+            EmptyModel,
+            json=request_model.to_api_request_json(),
+            api_key=self._get_api_key(),
         )
 
     async def get_asset_operations(

--- a/x10/perpetual/transfer_object.py
+++ b/x10/perpetual/transfer_object.py
@@ -42,6 +42,7 @@ def create_transfer_object(
     expiration_timestamp = calc_expiration_timestamp()
     stark_amount = (amount * market.collateral_asset.settlement_resolution).to_integral_exact()
 
+    nonce = generate_nonce()
     transfer_hash = get_transfer_msg(
         asset_id=int(market.l2_config.collateral_id, base=16),
         asset_id_fee=ASSET_ID_FEE,
@@ -49,7 +50,7 @@ def create_transfer_object(
         sender_position_id=int(from_account.l2_vault),
         receiver_position_id=int(to_account.l2_vault),
         src_fee_position_id=int(from_account.l2_vault),
-        nonce=generate_nonce(),
+        nonce=nonce,
         amount=int(stark_amount),
         max_amount_fee=MAX_AMOUNT_FEE,
         expiration_timestamp=expiration_timestamp,
@@ -60,7 +61,7 @@ def create_transfer_object(
         amount=int(stark_amount),
         asset_id=int(market.l2_config.collateral_id, base=16),
         expiration_timestamp=expiration_timestamp,
-        nonce=generate_nonce(),
+        nonce=nonce,
         receiver_position_id=int(to_account.l2_vault),
         receiver_public_key=to_account.l2_key,
         sender_position_id=int(from_account.l2_vault),


### PR DESCRIPTION
## Changes
- Expose `account.transfer` method
- Fix `nonce` generation

```
{
    "status": "OK",
    "data": {
        "validSignature": true,
        "id": 1818709041853521920
    }
}
```

This pull request includes several changes to the `x10/perpetual/trading_client` and `x10/perpetual/transfer_object` modules to enhance functionality and improve code maintainability. The key changes involve adding a new HTTP request method, renaming a method for consistency, and reusing a generated nonce in the transfer object creation.

### Enhancements to HTTP Requests:
* [`x10/perpetual/trading_client/account_module.py`](diffhunk://#diff-399af48483c68304948b3caf8320d1593104521c5c9ed51f47ea5e53e5cc8400L18-R23): Added `send_post_request` to the list of imported functions from `x10.utils.http`.
* [`x10/perpetual/trading_client/account_module.py`](diffhunk://#diff-399af48483c68304948b3caf8320d1593104521c5c9ed51f47ea5e53e5cc8400L164-R174): Updated the `__transfer` method to use `send_post_request` instead of `send_patch_request`.

### Code Consistency and Maintainability:
* [`x10/perpetual/trading_client/account_module.py`](diffhunk://#diff-399af48483c68304948b3caf8320d1593104521c5c9ed51f47ea5e53e5cc8400L144-R149): Renamed the `__transfer` method to `transfer` for better readability and consistency.

### Improvements to Transfer Object Creation:
* [`x10/perpetual/transfer_object.py`](diffhunk://#diff-3f1b8e350238e46018b93ad1be15c21124f529de415fcc336a8625e1383d4020R45-R53): Introduced a reusable `nonce` variable in the `create_transfer_object` function to ensure the same nonce is used consistently. [[1]](diffhunk://#diff-3f1b8e350238e46018b93ad1be15c21124f529de415fcc336a8625e1383d4020R45-R53) [[2]](diffhunk://#diff-3f1b8e350238e46018b93ad1be15c21124f529de415fcc336a8625e1383d4020L63-R64)