### PR TITLE
Slow withdrawals (reclaim)

### DIFF
--- a/x10/perpetual/contract.py
+++ b/x10/perpetual/contract.py
@@ -1,10 +1,12 @@
 import json
 import os
+from typing import Callable
 
 from web3 import Web3
 
 from x10.perpetual.configuration import EndpointConfig
 from x10.perpetual.markets import MarketModel
+from x10.utils.string import is_hex_string
 
 DEFAULT_API_TIMEOUT = 30
 
@@ -15,18 +17,41 @@ ABI_FOLDER = os.path.join(
 STARK_PERPETUAL_ABI = "stark-perpetual.json"
 
 
-def call_stark_perpetual_withdraw(contract_address: str, eth_address: str, market: MarketModel, config: EndpointConfig):
+def call_stark_perpetual_withdraw(
+    contract_address: str,
+    eth_address: str,
+    market: MarketModel,
+    config: EndpointConfig,
+    get_eth_private_key: Callable[[], str],
+):
     web3_provider = Web3.HTTPProvider(config.chain_rpc_url, request_kwargs={"timeout": DEFAULT_API_TIMEOUT})
     web3 = Web3(web3_provider)
 
+    checksum_contract_address = Web3.to_checksum_address(contract_address)
+    checksum_eth_address = Web3.to_checksum_address(eth_address)
+
     contract = web3.eth.contract(
-        address=Web3.to_checksum_address(contract_address),
+        address=checksum_contract_address,
         abi=json.load(open(os.path.join(ABI_FOLDER, STARK_PERPETUAL_ABI), "r")),
     )
 
     method = contract.functions.withdraw(
-        int(eth_address, base=16),
+        int(checksum_eth_address, base=16),
         int(market.l2_config.collateral_id, base=16),
     )
 
-    return method.transact()
+    eth_private_key = get_eth_private_key()
+
+    assert is_hex_string(eth_private_key)
+
+    signed_tx = web3.eth.account.sign_transaction(
+        method.build_transaction(
+            {
+                "from": checksum_eth_address,
+                "nonce": web3.eth.get_transaction_count(checksum_eth_address),
+            }
+        ),
+        eth_private_key,
+    )
+
+    return web3.eth.send_raw_transaction(signed_tx.rawTransaction)

--- a/x10/perpetual/trading_client/account_module.py
+++ b/x10/perpetual/trading_client/account_module.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from x10.perpetual.accounts import AccountLeverage, AccountModel
 from x10.perpetual.assets import (
@@ -202,12 +202,19 @@ class AccountModule(BaseModule):
             api_key=self._get_api_key(),
         )
 
-    def __withdrawal_slow_reclaim(self, contract_address: str, eth_address: str, market: MarketModel):
+    def withdrawal_slow_reclaim(
+        self,
+        contract_address: str,
+        eth_address: str,
+        market: MarketModel,
+        get_eth_private_key: Callable[[], str],
+    ):
         return call_stark_perpetual_withdraw(
             contract_address,
             eth_address,
             market,
             self._get_endpoint_config(),
+            get_eth_private_key,
         )
 
     async def get_asset_operations(


### PR DESCRIPTION
## Changes
- Add `account.withdrawal_slow_reclaim` method

Usage example:
```python
eth_address = "0x..."
eth_private_key = "0x..."

markets = await trading_client.markets_info.get_markets()
settings = await trading_client.info.get_settings()

tx_hash = trading_client.account.withdrawal_slow_reclaim(
    settings.data.stark_ex_contract_address,
    eth_address,
    markets.data[0],
    lambda: eth_private_key,
)
```
