### PR TITLE
Add get order by ID (internal/external) endpoints

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -13,13 +13,9 @@ def get_adjust_price_by_pct(config: TradingConfigModel):
 
 
 async def find_order_and_cancel(*, trading_client: PerpetualTradingClient, logger: Logger, order_id: str):
-    open_orders = await trading_client.account.get_open_orders()
+    open_order = await trading_client.account.get_order_by_id(order_id)
 
-    for order in open_orders.data:
-        if order.id == order_id:
-            logger.info("Found placed order: %s", order.to_pretty_json())
-            break
-
+    logger.info("Found placed order: %s", open_order.to_pretty_json())
     logger.info("Cancelling placed order...")
 
     await trading_client.orders.cancel_order(order_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "x10-python-trading-starknet"
-version = "0.0.13"
+version = "0.0.14"
 description = "Python client for X10 API"
 authors = ["X10 <tech@ex10.org>"]
 repository = "https://github.com/x10xchange/python_sdk"

--- a/x10/perpetual/trading_client/account_module.py
+++ b/x10/perpetual/trading_client/account_module.py
@@ -107,6 +107,24 @@ class AccountModule(BaseModule):
         )
         return await send_get_request(await self.get_session(), url, List[OpenOrderModel], api_key=self._get_api_key())
 
+    async def get_order_by_id(self, order_id: int) -> WrappedApiResponse[OpenOrderModel]:
+        """
+        https://api.docs.extended.exchange/#get-order-by-id
+        """
+
+        url = self._get_url("/user/orders/<order_id>", order_id=order_id)
+
+        return await send_get_request(await self.get_session(), url, OpenOrderModel, api_key=self._get_api_key())
+
+    async def get_order_by_external_id(self, external_id: str) -> WrappedApiResponse[list[OpenOrderModel]]:
+        """
+        https://api.docs.extended.exchange/#get-order-by-external-id
+        """
+
+        url = self._get_url("/user/orders/external/<external_id>", external_id=external_id)
+
+        return await send_get_request(await self.get_session(), url, list[OpenOrderModel], api_key=self._get_api_key())
+
     async def get_trades(
         self,
         market_names: List[str],


### PR DESCRIPTION
## Changes
- Add endpoints for:
  - https://api.docs.extended.exchange/#get-order-by-id
  - https://api.docs.extended.exchange/#get-orders-by-external-id

```python
trading_client.account.get_order_by_id(order_id)
trading_client.account.get_order_by_external_id(external_order_id)
```

Resolves https://github.com/x10xchange/python_sdk/issues/47