### PR TITLE
fix: correct testnet socket stream url

### DIFF
--- a/x10/perpetual/configuration.py
+++ b/x10/perpetual/configuration.py
@@ -35,9 +35,7 @@ TESTNET_CONFIG = EndpointConfig(
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",
-    starknet_domain=StarknetDomain(
-        name="Perpetuals", version="v0", chain_id="SN_SEPOLIA", revision="1"
-    ),
+    starknet_domain=StarknetDomain(name="Perpetuals", version="v0", chain_id="SN_SEPOLIA", revision="1"),
 )
 
 MAINNET_CONFIG = EndpointConfig(
@@ -51,7 +49,5 @@ MAINNET_CONFIG = EndpointConfig(
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",
-    starknet_domain=StarknetDomain(
-        name="Perpetuals", version="v0", chain_id="SN_MAIN", revision="1"
-    ),
+    starknet_domain=StarknetDomain(name="Perpetuals", version="v0", chain_id="SN_MAIN", revision="1"),
 )

--- a/x10/perpetual/configuration.py
+++ b/x10/perpetual/configuration.py
@@ -27,7 +27,7 @@ class EndpointConfig:
 TESTNET_CONFIG = EndpointConfig(
     chain_rpc_url="https://rpc.sepolia.org",
     api_base_url="https://api.starknet.sepolia.extended.exchange/api/v1",
-    stream_url="wss://starknet.sepolia.extended.exchange/stream.extended.exchange/v1",
+    stream_url="wss://api.starknet.sepolia.extended.exchange/stream.extended.exchange/v1",
     onboarding_url="https://api.starknet.sepolia.extended.exchange",
     signing_domain="starknet.sepolia.extended.exchange",
     collateral_asset_contract="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
@@ -35,7 +35,9 @@ TESTNET_CONFIG = EndpointConfig(
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",
-    starknet_domain=StarknetDomain(name="Perpetuals", version="v0", chain_id="SN_SEPOLIA", revision="1"),
+    starknet_domain=StarknetDomain(
+        name="Perpetuals", version="v0", chain_id="SN_SEPOLIA", revision="1"
+    ),
 )
 
 MAINNET_CONFIG = EndpointConfig(
@@ -49,5 +51,7 @@ MAINNET_CONFIG = EndpointConfig(
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",
-    starknet_domain=StarknetDomain(name="Perpetuals", version="v0", chain_id="SN_MAIN", revision="1"),
+    starknet_domain=StarknetDomain(
+        name="Perpetuals", version="v0", chain_id="SN_MAIN", revision="1"
+    ),
 )


### PR DESCRIPTION
  ## Problem

  The `TESTNET_CONFIG` uses an incorrect WebSocket URL for private streams:
  - Current: `wss://starknet.sepolia.extended.exchange/stream.extended.exchange/v1`
  - Should be: `wss://api.starknet.sepolia.extended.exchange/stream.extended.exchange/v1` (source: [Extended API docs](https://api.docs.extended.exchange/#private-websocket-streams))

  This causes **HTTP 401 Unauthorized** errors when connecting to private WebSocket streams (e.g., account updates) on testnet.

  ## Solution

  Add the `api.` prefix to the testnet WebSocket URL to match the Extended API documentation

  ## Testing

  Tested on Starknet Sepolia testnet:

  **Before fix:**
  ```python
  stream_client.subscribe_to_account_updates(api_key)
  # Result: HTTP 401 Unauthorized

  After fix:
  stream_client.subscribe_to_account_updates(api_key)
  # Result: Connection successful, receiving events