### PR TITLE
Update parameter types according to API docs

### DIFF
--- a/examples/01_create_limit_order.py
+++ b/examples/01_create_limit_order.py
@@ -12,7 +12,7 @@ from x10.perpetual.trading_client import PerpetualTradingClient
 
 LOGGER = logging.getLogger()
 MARKET_NAME = ETH_USD_MARKET
-ENDPOINT_CONFIG = MAINNET_CONFIG
+ENDPOINT_CONFIG = MAINNET_CONFIG # replace with TESTNET_CONFIG for testnet
 
 
 async def run_example():

--- a/examples/01_create_limit_order.py
+++ b/examples/01_create_limit_order.py
@@ -12,7 +12,7 @@ from x10.perpetual.trading_client import PerpetualTradingClient
 
 LOGGER = logging.getLogger()
 MARKET_NAME = ETH_USD_MARKET
-ENDPOINT_CONFIG = MAINNET_CONFIG # replace with TESTNET_CONFIG for testnet
+ENDPOINT_CONFIG = MAINNET_CONFIG  # replace with TESTNET_CONFIG for testnet
 
 
 async def run_example():

--- a/x10/perpetual/trading_client/account_module.py
+++ b/x10/perpetual/trading_client/account_module.py
@@ -127,7 +127,7 @@ class AccountModule(BaseModule):
 
     async def get_trades(
         self,
-        market_names: List[str],
+        market_names: Optional[List[str]] = None,
         trade_side: Optional[OrderSide] = None,
         trade_type: Optional[TradeType] = None,
         cursor: Optional[int] = None,
@@ -147,7 +147,7 @@ class AccountModule(BaseModule):
         )
 
     async def get_fees(
-        self, *, market_names: List[str], builder_id: Optional[int] = None
+        self, *, market_names: Optional[List[str]] = None, builder_id: Optional[int] = None
     ) -> WrappedApiResponse[List[TradingFeeModel]]:
         """
         https://api.docs.extended.exchange/#get-fees
@@ -162,7 +162,7 @@ class AccountModule(BaseModule):
         )
         return await send_get_request(await self.get_session(), url, List[TradingFeeModel], api_key=self._get_api_key())
 
-    async def get_leverage(self, market_names: List[str]) -> WrappedApiResponse[List[AccountLeverage]]:
+    async def get_leverage(self, market_names: Optional[List[str]] = None) -> WrappedApiResponse[List[AccountLeverage]]:
         """
         https://api.docs.extended.exchange/#get-current-leverage
         """

--- a/x10/perpetual/trading_client/markets_information_module.py
+++ b/x10/perpetual/trading_client/markets_information_module.py
@@ -37,7 +37,7 @@ class MarketsInformationModule(BaseModule):
         market_name: str,
         candle_type: CandleType,
         interval: CandleInterval,
-        limit: Optional[int] = None,
+        limit: int,
         end_time: Optional[datetime] = None,
     ):
         """


### PR DESCRIPTION
https://api.docs.extended.exchange/#get-trades
params market is not required => set as Optional

https://api.docs.extended.exchange/#get-fees
params market is not required => set as Optional

https://api.docs.extended.exchange/#get-current-leverage
params market is not required => set as Optional

https://api.docs.extended.exchange/#get-candles-history
params limit is required => removed Optional