### PR TITLE
Fix TESTNET_CONFIG collateral_asset_id + add CONDITIONAL order support

### DIFF
--- a/tests/perpetual/test_transfer_object.py
+++ b/tests/perpetual/test_transfer_object.py
@@ -35,10 +35,10 @@ async def test_create_transfer(mocker: MockerFixture, create_trading_account, cr
                 "fromVault": trading_account.vault,
                 "toVault": int(accounts[1].l2_vault),
                 "amount": "1.1",
-                "transferredAsset": "0x1",
+                "transferredAsset": "0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
                 "settlement": {
                     "amount": 1100000,
-                    "assetId": "0x1",
+                    "assetId": "0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
                     "expirationTimestamp": 1706231337,
                     "nonce": 1473459052,
                     "receiverPositionId": int(accounts[1].l2_vault),
@@ -46,8 +46,8 @@ async def test_create_transfer(mocker: MockerFixture, create_trading_account, cr
                     "senderPositionId": trading_account.vault,
                     "senderPublicKey": f"{hex(trading_account.public_key)}",
                     "signature": {
-                        "r": "0x21f353080b04ab862474d0d2985f4d223087a89193a3a8bdea3de320f845cf8",
-                        "s": "0x6f70daa9e65037d97ccf0667cc6f1368b7b01a93d0ededf929b53be3f177d96",
+                        "r": "0x23d69eafa600b088844ecd6d413f0858a9f66ce5521a5de2836d97809521af2",
+                        "s": "0x67eb0ec88db83455721e8a628fa6fca23085ea42e5d00a6cd2260f8fa5d1ce",
                     },
                 },
             }

--- a/x10/perpetual/configuration.py
+++ b/x10/perpetual/configuration.py
@@ -32,9 +32,9 @@ TESTNET_CONFIG = EndpointConfig(
     signing_domain="starknet.sepolia.extended.exchange",
     collateral_asset_contract="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
     asset_operations_contract="",
-    collateral_asset_on_chain_id="0x1",
+    collateral_asset_on_chain_id="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
     collateral_decimals=6,
-    collateral_asset_id="0x1",
+    collateral_asset_id="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
     starknet_domain=StarknetDomain(name="Perpetuals", version="v0", chain_id="SN_SEPOLIA", revision="1"),
 )
 

--- a/x10/perpetual/order_object.py
+++ b/x10/perpetual/order_object.py
@@ -12,11 +12,13 @@ from x10.perpetual.order_object_settlement import (
     create_order_settlement_data,
 )
 from x10.perpetual.orders import (
+    CreateOrderConditionalTriggerModel,
     CreateOrderTpslTriggerModel,
     NewOrderModel,
     OrderPriceType,
     OrderSide,
     OrderTpslType,
+    OrderTriggerDirection,
     OrderTriggerPriceType,
     OrderType,
     SelfTradeProtectionLevel,
@@ -57,6 +59,10 @@ def create_order_object(
     tp_sl_type: Optional[OrderTpslType] = None,
     take_profit: Optional[OrderTpslTriggerParam] = None,
     stop_loss: Optional[OrderTpslTriggerParam] = None,
+    trigger_price: Optional[Decimal] = None,
+    trigger_price_type: Optional[OrderTriggerPriceType] = None,
+    trigger_direction: Optional[OrderTriggerDirection] = None,
+    execution_price_type: Optional[OrderPriceType] = None,
 ) -> NewOrderModel:
     """
     Creates an order object to be placed on the exchange using the `place_order` method.
@@ -92,6 +98,10 @@ def create_order_object(
         tp_sl_type=tp_sl_type,
         take_profit=take_profit,
         stop_loss=stop_loss,
+        trigger_price=trigger_price,
+        trigger_price_type=trigger_price_type,
+        trigger_direction=trigger_direction,
+        execution_price_type=execution_price_type,
     )
 
 
@@ -161,6 +171,10 @@ def __create_order_object(
     tp_sl_type: Optional[OrderTpslType] = None,
     take_profit: Optional[OrderTpslTriggerParam] = None,
     stop_loss: Optional[OrderTpslTriggerParam] = None,
+    trigger_price: Optional[Decimal] = None,
+    trigger_price_type: Optional[OrderTriggerPriceType] = None,
+    trigger_direction: Optional[OrderTriggerDirection] = None,
+    execution_price_type: Optional[OrderPriceType] = None,
 ) -> NewOrderModel:
     def validate_market_order():
         if post_only:
@@ -182,7 +196,16 @@ def __create_order_object(
         if price != Decimal(0):
             raise ValueError("`price` must be 0 for TPSL orders")
 
-    if order_type not in [OrderType.LIMIT, OrderType.MARKET, OrderType.TPSL]:
+    def validate_conditional_order():
+        if trigger_price is None or trigger_direction is None:
+            raise ValueError(
+                "CONDITIONAL orders require trigger_price and trigger_direction"
+            )
+
+        if post_only:
+            raise ValueError("CONDITIONAL orders must not be post-only")
+
+    if order_type not in [OrderType.LIMIT, OrderType.MARKET, OrderType.TPSL, OrderType.CONDITIONAL]:
         raise NotImplementedError(f"{order_type} order type is not supported yet")
 
     if exact_only:
@@ -198,6 +221,8 @@ def __create_order_object(
         validate_market_order()
     elif order_type == OrderType.TPSL:
         validate_tpsl_order()
+    elif order_type == OrderType.CONDITIONAL:
+        validate_conditional_order()
 
     if nonce is None:
         nonce = generate_nonce()
@@ -239,6 +264,15 @@ def __create_order_object(
             settlement_data_ctx=settlement_data_ctx,
         )
 
+    trigger = None
+    if order_type == OrderType.CONDITIONAL:
+        trigger = CreateOrderConditionalTriggerModel(
+            trigger_price=trigger_price,
+            trigger_price_type=trigger_price_type or OrderTriggerPriceType.LAST,
+            direction=trigger_direction,
+            execution_price_type=execution_price_type or OrderPriceType.LIMIT,
+        )
+
     order_id = str(settlement_data.order_hash) if order_external_id is None else order_external_id
     order = NewOrderModel(
         id=order_id,
@@ -255,6 +289,7 @@ def __create_order_object(
         nonce=Decimal(nonce),
         cancel_id=previous_order_external_id,
         settlement=settlement_data.settlement if order_type != OrderType.TPSL else None,
+        trigger=trigger,
         tp_sl_type=tp_sl_type,
         take_profit=create_tpsl_trigger_model(take_profit),
         stop_loss=create_tpsl_trigger_model(stop_loss),


### PR DESCRIPTION
## Summary

- **TESTNET_CONFIG fix**: `collateral_asset_id` and `collateral_asset_on_chain_id` were set to `"0x1"` instead of the actual contract address (`0x31857...054`), causing `transfer()` to fail with "Asset id in the settlement does not match"
- **CONDITIONAL order support**: `create_order_object()` now supports `OrderType.CONDITIONAL` with `trigger_price`, `trigger_price_type`, `trigger_direction`, and `execution_price_type` parameters. Previously, CONDITIONAL was defined in the enum and models but blocked by `NotImplementedError` in `create_order_object`.

## Changes

### `x10/perpetual/configuration.py`
- Fixed `TESTNET_CONFIG.collateral_asset_id` and `collateral_asset_on_chain_id` to match `collateral_asset_contract`

### `x10/perpetual/order_object.py`
- Added `CreateOrderConditionalTriggerModel` and `OrderTriggerDirection` to top-level imports
- Added 4 optional parameters: `trigger_price`, `trigger_price_type`, `trigger_direction`, `execution_price_type`
- Added `validate_conditional_order()` following existing MARKET/TPSL validation pattern
- CONDITIONAL orders include settlement (server requires StarkEx signature for CONDITIONAL)
- Constructs `CreateOrderConditionalTriggerModel` with sensible defaults (`LAST` trigger, `LIMIT` execution)

### `tests/perpetual/test_transfer_object.py`
- Updated expected `assetId`, `transferredAsset`, and `signature` values to reflect corrected TESTNET_CONFIG collateral

## Verification

- Tested on Starknet Sepolia testnet:
  - CONDITIONAL BUY/SELL orders placed successfully
  - Transfer with corrected collateral_asset_id works
  - LIMIT orders unaffected (backward compatible)
- All new parameters are `Optional` with `None` defaults — no breaking changes for existing callers

## Note on existing test failures

6 tests in `test_limit_order_object.py` and `test_tpsl_order_object.py` fail on the current `starknet` branch as well (unrelated to this PR).