### PR TITLE
Support CONDITIONAL order type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Extended Python SDK
+
+Thanks for showing interest to contribute to Extended Python SDK!
+
+## Discuss changes before starting to work on them
+
+> [!WARNING]
+> Please note that SDK is under an active development / reworking.
+
+Please first discuss the change you wish to make by creating an issue or reaching out to us in the
+[devs-api-trading](https://discord.com/channels/1193905940076953660/1269958891819765842) Discord channel
+before making a change. This helps everyone to be on the same page and makes the chances of your contributions
+being integrated into the project much higher. We do not accept PRs larger than 500 LOC at the moment,
+as we are still working on the structure of the SDK and its core features. If we identify misalignments between
+your PR and our roadmap / vision, it might be easier for us to push our own implementation to avoid
+unnecessary iterations.
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under its [LICENSE](LICENSE).
+
+## Env setup
+
+Make sure you have [poetry](https://python-poetry.org/) installed.
+
+- Clone the repository: `git@github.com:x10xchange/python_sdk.git`
+- Navigate to the project directory: `cd python_sdk`
+- Create a virtual environment: `poetry shell`
+- Install dependencies: `poetry install`
+- Update `examples/placed_order_example.py` with your credentials
+- Run it: `python -m examples.placed_order_example`
+
+Custom commands:
+- `make format` - format code with `black`
+- `make lint` - run `safety`, `black`, `flake8` and `mypy` checks
+- `make test` - run tests

--- a/README.md
+++ b/README.md
@@ -366,20 +366,6 @@ def get_private_key_from_eth_signature(eth_signature: str) -> int:
 There is a new function `deposit` available on the [`AccountModule`](x10/perpetual/trading_client/account_module.py) which provides the ability to directly deposit USDC into your StarkEx account. For more details check out `call_stark_perpetual_deposit` in [contract.py](x10/perpetual/contract.py)
 
 
-## Contribution
+## Contributing
 
-Make sure you have [poetry](https://python-poetry.org/) installed.
-
-- Clone the repository: `git@github.com:x10xchange/python_sdk.git`
-- Navigate to the project directory: `cd python_sdk`
-- Create a virtual environment: `poetry shell`
-- Install dependencies: `poetry install`
-- Update `examples/placed_order_example.py` with your credentials
-- Run it: `python -m examples.placed_order_example`
-
-Custom commands:
-- `make format` - format code with `black`
-- `make lint` - run `safety`, `black`, `flake8` and `mypy` checks
-- `make test` - run tests
-
-
+See the [CONTRIBUTING.md](CONTRIBUTING.md) file.

--- a/examples/create_conditional_order.py
+++ b/examples/create_conditional_order.py
@@ -1,20 +1,25 @@
 import logging
 from asyncio import run
-from decimal import Decimal
 
 from examples.init_env import init_env
+from examples.utils import find_order_and_cancel, get_adjust_price_by_pct
 from x10.config import BTC_USD_MARKET
 from x10.perpetual.accounts import StarkPerpetualAccount
 from x10.perpetual.configuration import TESTNET_CONFIG
-from x10.perpetual.order_object import create_order_object
-from x10.perpetual.orders import OrderSide, OrderType, TimeInForce
+from x10.perpetual.order_object import OrderConditionalTriggerParam, create_order_object
+from x10.perpetual.orders import (
+    OrderPriceType,
+    OrderSide,
+    OrderTriggerDirection,
+    OrderTriggerPriceType,
+    OrderType,
+    TimeInForce,
+)
 from x10.perpetual.trading_client import PerpetualTradingClient
-from x10.utils.order import get_price_with_slippage
 
 LOGGER = logging.getLogger()
 MARKET_NAME = BTC_USD_MARKET
 ENDPOINT_CONFIG = TESTNET_CONFIG
-SLIPPAGE = Decimal(0.0075)
 
 
 async def run_example():
@@ -27,34 +32,33 @@ async def run_example():
     )
     trading_client = PerpetualTradingClient(ENDPOINT_CONFIG, stark_account)
     markets_dict = await trading_client.markets_info.get_markets_dict()
-    market_stats = await trading_client.markets_info.get_market_statistics(market_name=MARKET_NAME)
 
     market = markets_dict[MARKET_NAME]
+    adjust_price_by_pct = get_adjust_price_by_pct(market.trading_config)
 
-    order_side = OrderSide.SELL
     order_size = market.trading_config.min_order_size
+    order_price = adjust_price_by_pct(market.market_stats.bid_price, -15.0)
+    order_trigger_price = adjust_price_by_pct(market.market_stats.bid_price, -10.0)
 
-    best_market_price = market_stats.data.ask_price if order_side == OrderSide.BUY else market_stats.data.bid_price
-    order_price = get_price_with_slippage(
-        side=order_side,
-        price=best_market_price,
-        min_price_change=market.trading_config.min_price_change,
-        slippage=SLIPPAGE,
-    )
-
-    LOGGER.info("Creating MARKET order object for market: %s", market.name)
+    LOGGER.info("Creating CONDITIONAL order object for market: %s", market.name)
 
     new_order = create_order_object(
         account=stark_account,
-        order_type=OrderType.MARKET,
+        order_type=OrderType.CONDITIONAL,
         starknet_domain=ENDPOINT_CONFIG.starknet_domain,
         market=market,
-        side=order_side,
+        side=OrderSide.BUY,
         amount_of_synthetic=order_size,
-        price=order_price,
-        time_in_force=TimeInForce.IOC,
+        price=market.trading_config.round_price(order_price),
+        time_in_force=TimeInForce.GTT,
         reduce_only=False,
-        post_only=False,
+        post_only=True,
+        trigger=OrderConditionalTriggerParam(
+            trigger_price=order_trigger_price,
+            trigger_price_type=OrderTriggerPriceType.LAST,
+            direction=OrderTriggerDirection.DOWN,
+            execution_price_type=OrderPriceType.LIMIT,
+        ),
     )
 
     LOGGER.info("Placing order...")
@@ -62,7 +66,8 @@ async def run_example():
     placed_order = await trading_client.orders.place_order(order=new_order)
 
     LOGGER.info("Order is placed: %s", placed_order.to_pretty_json())
-    LOGGER.warning("Don't forget to reduce/close your position!")
+
+    await find_order_and_cancel(trading_client=trading_client, logger=LOGGER, order_id=placed_order.data.id)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "x10-python-trading-starknet"
-version = "1.1.0"
+version = "1.2.0"
 description = "Python client for X10 API"
 authors = ["X10 <tech@ex10.org>"]
 repository = "https://github.com/x10xchange/python_sdk"

--- a/tests/perpetual/order_object/test_conditional_order_object.py
+++ b/tests/perpetual/order_object/test_conditional_order_object.py
@@ -1,0 +1,88 @@
+from decimal import Decimal
+
+import pytest
+from freezegun import freeze_time
+from hamcrest import assert_that, equal_to
+from pytest_mock import MockerFixture
+
+from x10.perpetual.configuration import TESTNET_CONFIG
+from x10.perpetual.orders import (
+    OrderPriceType,
+    OrderSide,
+    OrderTriggerDirection,
+    OrderTriggerPriceType,
+    OrderType,
+)
+
+FROZEN_NONCE = 1473459052
+
+
+@freeze_time("2024-01-05 01:08:56.860694")
+@pytest.mark.asyncio
+async def test_create_buy_order(mocker: MockerFixture, create_trading_account, create_btc_usd_market):
+    mocker.patch("x10.utils.nonce.generate_nonce", return_value=FROZEN_NONCE)
+
+    from x10.perpetual.order_object import (
+        OrderConditionalTriggerParam,
+        create_order_object,
+    )
+
+    trading_account = create_trading_account()
+    btc_usd_market = create_btc_usd_market()
+    order_obj = create_order_object(
+        account=trading_account,
+        order_type=OrderType.CONDITIONAL,
+        market=btc_usd_market,
+        amount_of_synthetic=Decimal("0.00100000"),
+        price=Decimal("43445.11680000"),
+        side=OrderSide.BUY,
+        starknet_domain=TESTNET_CONFIG.starknet_domain,
+        trigger=OrderConditionalTriggerParam(
+            trigger_price=Decimal("43400"),
+            trigger_price_type=OrderTriggerPriceType.INDEX,
+            direction=OrderTriggerDirection.UP,
+            execution_price_type=OrderPriceType.MARKET,
+        ),
+    )
+
+    assert_that(
+        order_obj.to_api_request_json(),
+        equal_to(
+            {
+                "id": "3046028740943923525485052516594435355254317624383309761214907448964702854761",
+                "market": "BTC-USD",
+                "type": "CONDITIONAL",
+                "side": "BUY",
+                "qty": "0.00100000",
+                "price": "43445.11680000",
+                "reduceOnly": False,
+                "postOnly": False,
+                "timeInForce": "GTT",
+                "expiryEpochMillis": 1704420536861,
+                "fee": "0.0005",
+                "nonce": "1473459052",
+                "selfTradeProtectionLevel": "ACCOUNT",
+                "cancelId": None,
+                "settlement": {
+                    "signature": {
+                        "r": "0x5d076ebb3418b8d730b39b922559e84bed72802bd88dd55fa60243f6f561246",
+                        "s": "0x4aece4a3326fb4f5f614d76969654cf5247fa08ab7a45870091397c9829c33b",
+                    },
+                    "starkKey": "0x61c5e7e8339b7d56f197f54ea91b776776690e3232313de0f2ecbd0ef76f466",
+                    "collateralPosition": "10002",
+                },
+                "trigger": {
+                    "triggerPrice": "43400",
+                    "triggerPriceType": "INDEX",
+                    "direction": "UP",
+                    "executionPriceType": "MARKET",
+                },
+                "tpSlType": None,
+                "takeProfit": None,
+                "stopLoss": None,
+                "debuggingAmounts": {"collateralAmount": "-43445117", "feeAmount": "21723", "syntheticAmount": "1000"},
+                "builderFee": None,
+                "builderId": None,
+            }
+        ),
+    )

--- a/x10/perpetual/configuration.py
+++ b/x10/perpetual/configuration.py
@@ -11,17 +11,27 @@ class StarknetDomain:
 
 @dataclass
 class EndpointConfig:
+    """
+    Attributes:
+        asset_operations_contract (str): Field is deprecated and will be removed.
+        collateral_asset_contract (str): Field is deprecated and will be removed.
+        collateral_asset_on_chain_id (str): Field is deprecated and will be removed.
+        collateral_decimals (int): Field is deprecated and will be removed.
+        collateral_asset_id (str): Field is deprecated and will be removed.
+    """
+
     chain_rpc_url: str
     api_base_url: str
     stream_url: str
     onboarding_url: str
     signing_domain: str
-    collateral_asset_contract: str
+    starknet_domain: StarknetDomain
+
     asset_operations_contract: str
+    collateral_asset_contract: str
     collateral_asset_on_chain_id: str
     collateral_decimals: int
     collateral_asset_id: str
-    starknet_domain: StarknetDomain
 
 
 TESTNET_CONFIG = EndpointConfig(
@@ -30,8 +40,8 @@ TESTNET_CONFIG = EndpointConfig(
     stream_url="wss://api.starknet.sepolia.extended.exchange/stream.extended.exchange/v1",
     onboarding_url="https://api.starknet.sepolia.extended.exchange",
     signing_domain="starknet.sepolia.extended.exchange",
-    collateral_asset_contract="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
     asset_operations_contract="",
+    collateral_asset_contract="0x31857064564ed0ff978e687456963cba09c2c6985d8f9300a1de4962fafa054",
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",
@@ -44,8 +54,8 @@ MAINNET_CONFIG = EndpointConfig(
     stream_url="wss://api.starknet.extended.exchange/stream.extended.exchange/v1",
     onboarding_url="https://api.starknet.extended.exchange",
     signing_domain="extended.exchange",
-    collateral_asset_contract="",
     asset_operations_contract="",
+    collateral_asset_contract="",
     collateral_asset_on_chain_id="0x1",
     collateral_decimals=6,
     collateral_asset_id="0x1",

--- a/x10/perpetual/order_object.py
+++ b/x10/perpetual/order_object.py
@@ -12,11 +12,13 @@ from x10.perpetual.order_object_settlement import (
     create_order_settlement_data,
 )
 from x10.perpetual.orders import (
+    CreateOrderConditionalTriggerModel,
     CreateOrderTpslTriggerModel,
     NewOrderModel,
     OrderPriceType,
     OrderSide,
     OrderTpslType,
+    OrderTriggerDirection,
     OrderTriggerPriceType,
     OrderType,
     SelfTradeProtectionLevel,
@@ -25,6 +27,14 @@ from x10.perpetual.orders import (
 from x10.utils.date import to_epoch_millis, utc_now
 from x10.utils.nonce import generate_nonce
 from x10.utils.order import calc_entire_position_size
+
+
+@dataclass(kw_only=True)
+class OrderConditionalTriggerParam:
+    trigger_price: Decimal
+    trigger_price_type: OrderTriggerPriceType
+    direction: OrderTriggerDirection
+    execution_price_type: OrderPriceType
 
 
 @dataclass(kw_only=True)
@@ -54,6 +64,7 @@ def create_order_object(
     builder_fee: Optional[Decimal] = None,
     builder_id: Optional[int] = None,
     reduce_only: bool = False,
+    trigger: Optional[OrderConditionalTriggerParam] = None,
     tp_sl_type: Optional[OrderTpslType] = None,
     take_profit: Optional[OrderTpslTriggerParam] = None,
     stop_loss: Optional[OrderTpslTriggerParam] = None,
@@ -89,6 +100,7 @@ def create_order_object(
         builder_fee=builder_fee,
         builder_id=builder_id,
         reduce_only=reduce_only,
+        trigger=trigger,
         tp_sl_type=tp_sl_type,
         take_profit=take_profit,
         stop_loss=stop_loss,
@@ -158,6 +170,7 @@ def __create_order_object(
     builder_fee: Optional[Decimal] = None,
     builder_id: Optional[int] = None,
     reduce_only: bool = False,
+    trigger: Optional[OrderConditionalTriggerParam] = None,
     tp_sl_type: Optional[OrderTpslType] = None,
     take_profit: Optional[OrderTpslTriggerParam] = None,
     stop_loss: Optional[OrderTpslTriggerParam] = None,
@@ -168,6 +181,10 @@ def __create_order_object(
 
         if time_in_force != TimeInForce.IOC:
             raise ValueError("MARKET orders must have `time_in_force` set to IOC")
+
+    def validate_conditional_order():
+        if not trigger:
+            raise ValueError("CONDITIONAL orders must have `trigger` specified")
 
     def validate_tpsl_order():
         if not reduce_only:
@@ -182,7 +199,7 @@ def __create_order_object(
         if price != Decimal(0):
             raise ValueError("`price` must be 0 for TPSL orders")
 
-    if order_type not in [OrderType.LIMIT, OrderType.MARKET, OrderType.TPSL]:
+    if order_type not in [OrderType.LIMIT, OrderType.MARKET, OrderType.CONDITIONAL, OrderType.TPSL]:
         raise NotImplementedError(f"{order_type} order type is not supported yet")
 
     if exact_only:
@@ -196,6 +213,8 @@ def __create_order_object(
 
     if order_type == OrderType.MARKET:
         validate_market_order()
+    elif order_type == OrderType.CONDITIONAL:
+        validate_conditional_order()
     elif order_type == OrderType.TPSL:
         validate_tpsl_order()
 
@@ -255,12 +274,20 @@ def __create_order_object(
         nonce=Decimal(nonce),
         cancel_id=previous_order_external_id,
         settlement=settlement_data.settlement if order_type != OrderType.TPSL else None,
+        trigger=CreateOrderConditionalTriggerModel(
+            trigger_price=trigger.trigger_price,
+            trigger_price_type=trigger.trigger_price_type,
+            direction=trigger.direction,
+            execution_price_type=trigger.execution_price_type,
+        )
+        if trigger
+        else None,
         tp_sl_type=tp_sl_type,
         take_profit=create_tpsl_trigger_model(take_profit),
         stop_loss=create_tpsl_trigger_model(stop_loss),
         debugging_amounts=settlement_data.debugging_amounts,
-        builderFee=builder_fee,
-        builderId=builder_id,
+        builder_fee=builder_fee,
+        builder_id=builder_id,
         reduce_only=reduce_only,
     )
 

--- a/x10/perpetual/orders.py
+++ b/x10/perpetual/orders.py
@@ -152,8 +152,8 @@ class NewOrderModel(X10BaseModel):
     take_profit: Optional[CreateOrderTpslTriggerModel] = None
     stop_loss: Optional[CreateOrderTpslTriggerModel] = None
     debugging_amounts: Optional[StarkDebuggingOrderAmountsModel] = None
-    builderFee: Optional[Decimal] = None
-    builderId: Optional[int] = None
+    builder_fee: Optional[Decimal] = None
+    builder_id: Optional[int] = None
 
 
 class PlacedOrderModel(X10BaseModel):


### PR DESCRIPTION
## Changes
- Add CONDITIONAL order type support
- Add `CONTRIBUTING` guide to reduce misunderstanding
- Mark `EndpointConfig` asset fields as deprecated (this data should be fetched not hardcoded)
- Fix builder fee / ID fields naming