### PR TITLE
Close all owned module sessions in PerpetualTradingClient.close()

### DIFF
--- a/tests/perpetual/test_trading_client.py
+++ b/tests/perpetual/test_trading_client.py
@@ -170,3 +170,24 @@ async def test_get_asset_operations(aiohttp_server, create_asset_operations, cre
             ]
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_close_closes_all_module_sessions():
+    from x10.perpetual.trading_client import PerpetualTradingClient
+
+    trading_client = PerpetualTradingClient(endpoint_config=TESTNET_CONFIG)
+
+    sessions = [
+        await trading_client.info.get_session(),
+        await trading_client.markets_info.get_session(),
+        await trading_client.account.get_session(),
+        await trading_client.orders.get_session(),
+        await trading_client.vault.get_session(),
+        await trading_client.testnet.get_session(),
+    ]
+
+    await trading_client.close()
+
+    for session in sessions:
+        assert session.closed

--- a/x10/perpetual/trading_client/trading_client.py
+++ b/x10/perpetual/trading_client/trading_client.py
@@ -99,9 +99,12 @@ class PerpetualTradingClient:
         return await self.__order_management_module.place_order(order)
 
     async def close(self):
+        await self.__info_module.close_session()
         await self.__info_markets_module.close_session()
         await self.__account_module.close_session()
         await self.__order_management_module.close_session()
+        await self.__vault_module.close_session()
+        await self.__testnet_module.close_session()
 
     async def __aenter__(self):
         return self


### PR DESCRIPTION
## Summary
- close the missing `info`, `vault`, and `testnet` module sessions in `PerpetualTradingClient.close()`
- add a regression test that opens a session through every public sub-client and verifies they are closed after `close()`

## Why
`PerpetualTradingClient` creates six module clients, but `close()` only cleaned up three of them. If a caller used `client.info`, `client.vault`, or `client.testnet`, their underlying `aiohttp` sessions could stay open and leak resources.

## Testing
- `python -m py_compile x10/perpetual/trading_client/trading_client.py tests/perpetual/test_trading_client.py`
- `pytest tests/perpetual/test_trading_client.py -k close_closes_all_module_sessions`  
  not runnable in my local environment because `hamcrest` is not installed

