### PR TITLE
Support private RPC stream topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Placing orders and receiving updates in a blocking (synchronous) manner.
 Provides functionality for subscribing to real-time WebSocket updates.
 Each topic (stream) requires a separate WebSocket connection.
 
+### RPC Streaming
+
+Provides functionality for subscribing to real-time WebSocket updates by using a single WebSocket connection.
+You can use this client to subscribe to multiple topics (streams) at once.
+
 ## MCP (experimental)
 
 > [!WARNING]

--- a/examples/cases/stream/subscribe_to_rpc_stream.py
+++ b/examples/cases/stream/subscribe_to_rpc_stream.py
@@ -3,13 +3,13 @@ import logging
 from asyncio import run
 from signal import SIGINT, SIGTERM
 
-from examples.utils import BTC_USD_MARKET, create_stream_rpc_client, init_env
+from examples.utils import BTC_USD_MARKET, create_rest_client, create_stream_rpc_client
 from x10.clients.streamrpc.subscription_params import (
+    AccountParams,
     CandlesParams,
     PricesParams,
     TradesParams,
 )
-from x10.config import get_config_by_name
 from x10.models.stream_rpc import StreamRpcResponseModel
 
 LOGGER = logging.getLogger()
@@ -21,22 +21,30 @@ def on_message(message: StreamRpcResponseModel) -> None:
 
 
 async def subscribe_to_rpc_stream(stop_event: asyncio.Event):
-    env_config = init_env()
-    client_config = get_config_by_name(env_config.client_config_name)
+    rest_client = create_rest_client()
+    main_account = await rest_client.account.get_account()
 
-    async with create_stream_rpc_client(client_config) as client:
+    async with create_stream_rpc_client(rest_client.config) as client:
         await client.ping()
 
         subscriptions_before = await client.list_subscriptions()
 
         LOGGER.info("Active subscriptions: %s", subscriptions_before)
 
-        await client.subscribe(params=TradesParams(market="BTC-USD"), handler=on_message)
+        btc_usd_trades_topic_id = await client.subscribe(params=TradesParams(market="BTC-USD"), handler=on_message)
         await client.subscribe(params=TradesParams(market="ETH-USD"), handler=on_message)
         await client.subscribe(params=PricesParams(price_type="index", market="ETH-USD"), handler=on_message)
         await client.subscribe(
             params=CandlesParams(candle_type="index", market="ETH-USD", interval="PT1M"), handler=on_message
         )
+        await client.subscribe(
+            params=AccountParams(
+                account=str(main_account.data.id),
+                api_key=rest_client.stark_account.api_key,
+            ),
+            handler=on_message,
+        )
+        await client.unsubscribe(topic_id=btc_usd_trades_topic_id)
 
         subscriptions_after = await client.list_subscriptions()
 

--- a/tests/clients/test_streamrpc_client.py
+++ b/tests/clients/test_streamrpc_client.py
@@ -64,7 +64,7 @@ async def test_candle_stream():
 
         msg = await asyncio.wait_for(received_messages.get(), timeout=5)
 
-        await client.unsubscribe(subscription_id)
+        await client.unsubscribe(topic_id=subscription_id)
         await client.close()
 
     assert_that(

--- a/x10/clients/streamrpc/streamrpc_client.py
+++ b/x10/clients/streamrpc/streamrpc_client.py
@@ -31,8 +31,6 @@ OnReconnectCallback = Callable[[list[str]], Coroutine[Any, Any, None]]
 
 class StreamRpcClient:
     """
-    EXPERIMENTAL! NOT TO BE USED IN PRODUCTION! TO BE IMPROVED IN THE UPCOMING VERSIONS.
-
     X10 WebSocket RPC client.
 
     Implements the JSON-RPC 2.0 like protocol over a WebSocket connection.
@@ -142,7 +140,7 @@ class StreamRpcClient:
 
         return params.topic_id
 
-    async def unsubscribe(self, topic_id: TopicId):
+    async def unsubscribe(self, *, topic_id: TopicId):
         """
         Cancel an active subscription.
 

--- a/x10/clients/streamrpc/subscription_params.py
+++ b/x10/clients/streamrpc/subscription_params.py
@@ -212,15 +212,14 @@ StreamRpcAccountUpdateType: TypeAlias = (
 )
 
 
-class _AccountParams(SubscribeParams[StreamRpcAccountUpdateType]):
+class AccountParams(SubscribeParams[StreamRpcAccountUpdateType]):
     """
-    NOT SUPPORTED DUE TO AUTH ISSUES. TO BE FIXED IN THE UPCOMING VERSIONS.
-
     Subscribe to the private account stream.
     """
 
-    def __init__(self, *, account: str) -> None:
+    def __init__(self, *, account: str, api_key: str) -> None:
         self.account = account
+        self.api_key = api_key
 
     @property
     def topic_id(self) -> str:
@@ -230,6 +229,7 @@ class _AccountParams(SubscribeParams[StreamRpcAccountUpdateType]):
         return {
             "scope": "account",
             "selector": {"account": self.account},
+            "apiKey": self.api_key,
         }
 
     def deserialize_data(self, data: dict[str, Any], msg_type: str) -> StreamRpcAccountUpdateType:

--- a/x10/models/balance.py
+++ b/x10/models/balance.py
@@ -27,8 +27,8 @@ class SpotBalanceModel(X10BaseModel):
     notional_value: Decimal
     contribution_factor: Decimal
     equity_contribution: Decimal
-    available_to_withdraw: Decimal
-    updated_at: int
+    available_to_withdraw: Optional[Decimal] = None
     absolute_pnl: Optional[Decimal] = None
     pnl_percentage: Optional[Decimal] = None
     average_entry_price: Optional[Decimal] = None
+    updated_at: int


### PR DESCRIPTION
## Changes
- Add private RPC stream topics support
- Fix `SpotBalanceModel`

**Demo (redacted)**

```
[2026-07-01 14:07:15,945 53443 8293851712 DEBUG] Sending GET https://api.starknet.extended.exchange/api/v1/user/account/info
[2026-07-01 14:07:16,968 53443 8293851712 DEBUG] Connecting to wss://api.starknet.extended.exchange/stream.extended.exchange/v2/rpc
[2026-07-01 14:07:19,007 53443 8293851712 DEBUG] Connected to wss://api.starknet.extended.exchange/stream.extended.exchange/v2/rpc
[2026-07-01 14:07:19,541 53443 8293851712 INFO] Active subscriptions: []
[2026-07-01 14:07:19,813 53443 8293851712 DEBUG] Subscribed to account.3375
[2026-07-01 14:07:19,819 53443 8293851712 INFO] Received message: type='ACCOUNT.ORDER' data=StreamRpcAccountOrdersModel(...) error=None ts=1782900440252 seq=0 subscription='account.3375'
[2026-07-01 14:07:19,819 53443 8293851712 INFO] Received message: type='ACCOUNT.BALANCE' data=StreamRpcAccountBalanceModel(...) error=None ts=1782900440253 seq=1 subscription='account.3375'
[2026-07-01 14:07:19,819 53443 8293851712 INFO] Received message: type='ACCOUNT.SPOT_BALANCE' data=StreamRpcAccountSpotBalancesModel(...) error=None ts=1782900440253 seq=2 subscription='account.3375'
[2026-07-01 14:07:19,819 53443 8293851712 INFO] Received message: type='ACCOUNT.POSITION' data=StreamRpcAccountPositionsModel(...) error=None ts=1782900440254 seq=3 subscription='account.3375'
[2026-07-01 14:07:20,050 53443 8293851712 INFO] Active subscriptions: ['account.3375']
[2026-07-01 14:07:23,803 53443 8293851712 INFO] Signal received, stopping...
[2026-07-01 14:07:24,059 53443 8293851712 DEBUG] Connection loop exited
```